### PR TITLE
Install mirage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  globals: {
+    server: true,
+  },
   root: true,
   parserOptions: {
     ecmaVersion: 2017,

--- a/app/controllers/intro.js
+++ b/app/controllers/intro.js
@@ -3,41 +3,27 @@ import sharedActions from '../mixins/shared-actions';
 
 
 export default Ember.Controller.extend(sharedActions, {
-	// these are placeholders, country and region data will be supplied through api
-	countries: [{title: 'United States'},{title: 'Canada'}],
-	// countries: Ember.computed(function(){
-	// 	Ember.$.ajax({
-	// 		type: "GET",
- //    	contentType: "text/xml",
-	// 		url: 'api/countries'
-	// 	}).then(function(response){
-	// 		console.log('test happened')
-	// 		return response;
-	// 	})
-	// }),
-	// regions:
-	selectedCountry: null,
-	// selectedRegion: null,
+	country: null,
+	region: null,
+	regionPlaceholder: Ember.computed('country', function(){
+		return "Search for a region in " + this.get('country').attributes.name;
+	}),
 	
 	actions: {
-		selectCountry: function(selected){
-			Ember.$.ajax({
-				type: "GET",
-      	contentType: "text/xml",
-				url: 'api/countries'
-			}).then(function(response){
-				for(var i=0; i < response.countries.length; i++) {console.log(response.countries[i].name)}
-			})
-			this.set('selectedCountry', selected);
-		},
-		// selectRegion: function(selected){
-		// 	this.set('selectedRegion', selected);
-		// 	console.log(this.get('selectedRegion').title)
-		// }
 		changeRoute: function(route){
 			// Create new record in store for this submission.
 			this.store.createRecord('submission', {});
 			this.transitionToRoute(route);
-		}
+		},
+		searchCountries: function(term) {
+      if (Ember.isBlank(term)) { return []; }
+      const url = 'api/countries'      
+      return Ember.$.ajax({ url }).then(json => json.data);
+    },
+    searchRegions: function(term) {
+      if (Ember.isBlank(term)) { return []; }
+      const url = 'api/regions'      
+      return Ember.$.ajax({ url }).then(json => json.data);
+    }
 	}
 });

--- a/app/controllers/intro.js
+++ b/app/controllers/intro.js
@@ -17,7 +17,7 @@ export default Ember.Controller.extend(sharedActions, {
 		},
 		searchCountries: function(term) {
       if (Ember.isBlank(term)) { return []; }
-      const url = 'api/countries'      
+      let url = 'api/countries'      
       return Ember.$.ajax({ url }).then(json => json.data);
     },
     searchRegions: function(term) {

--- a/app/controllers/intro.js
+++ b/app/controllers/intro.js
@@ -5,12 +5,29 @@ import sharedActions from '../mixins/shared-actions';
 export default Ember.Controller.extend(sharedActions, {
 	// these are placeholders, country and region data will be supplied through api
 	countries: [{title: 'United States'},{title: 'Canada'}],
+	// countries: Ember.computed(function(){
+	// 	Ember.$.ajax({
+	// 		type: "GET",
+ //    	contentType: "text/xml",
+	// 		url: 'api/countries'
+	// 	}).then(function(response){
+	// 		console.log('test happened')
+	// 		return response;
+	// 	})
+	// }),
 	// regions:
 	selectedCountry: null,
 	// selectedRegion: null,
 	
 	actions: {
 		selectCountry: function(selected){
+			Ember.$.ajax({
+				type: "GET",
+      	contentType: "text/xml",
+				url: 'api/countries'
+			}).then(function(response){
+				for(var i=0; i < response.countries.length; i++) {console.log(response.countries[i].name)}
+			})
 			this.set('selectedCountry', selected);
 		},
 		// selectRegion: function(selected){

--- a/app/controllers/intro.js
+++ b/app/controllers/intro.js
@@ -11,19 +11,25 @@ export default Ember.Controller.extend(sharedActions, {
 	
 	actions: {
 		changeRoute: function(route){
-			// Create new record in store for this submission.
-			this.store.createRecord('submission', {});
+			var country = this.get('country').attributes.code;
+			var region = this.get('region').name;
+			// Create new record in store for this submission, with country and region from user input
+			this.store.createRecord('submission', {country: country, region: region});
 			this.transitionToRoute(route);
 		},
 		searchCountries: function(term) {
       if (Ember.isBlank(term)) { return []; }
-      let url = 'api/countries'      
+      var url = 'api/countries';
+      // view request format in mirage/config.js 
       return Ember.$.ajax({ url }).then(json => json.data);
     },
     searchRegions: function(term) {
       if (Ember.isBlank(term)) { return []; }
-      const url = 'api/regions'      
-      return Ember.$.ajax({ url }).then(json => json.data);
+      var country = this.get('country').attributes.code;
+      var url = 'api/regions/' + country;
+      // returns regions for the country provided in the request
+      // view request format in mirage/config.js 
+      return Ember.$.ajax({ url });
     }
 	}
 });

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -13,7 +13,8 @@ export default DS.Model.extend({
 	maintainer_email: DS.attr('string'),
 	// columns to map
 	// test: DS.attr('string')
-	test: "test 2"
+	country: DS.attr('string'),
+	region: DS.attr('string')
 
 
 });

--- a/app/templates/intro.hbs
+++ b/app/templates/intro.hbs
@@ -21,9 +21,11 @@
 	      onchange=(action (mut region))
 	      as | regions |
 	    }}
-	      {{regions.attributes.name}}
+	      {{regions.name}}
 	    {{/power-select}}
     {{/if}}
+
+   
 
 	{{nav-buttons sendChangeRoute="changeRoute" next="data"}}
 </div>

--- a/app/templates/intro.hbs
+++ b/app/templates/intro.hbs
@@ -3,18 +3,27 @@
 	<p>
 		The user will begin by searching to see if data exists in their country and region. If it does, they will enter "edit mode," with fields pre-populated with existing data.
 	</p>
-		{{#ui-search source=countries searchFields=country onSearchQuery=(action (mut query)) onSelect=(action "selectCountry")}}
-		<!-- this inline style is temporary and needs to be fixed -->
-		  <input class="prompt" style="width:300px;text-align:center" type="text" placeholder="Search existing countries">
-		  <div class="results"></div>
-		{{/ui-search}}
-	<!-- <div>
-		{{#if selectedCountry}}
-			{{#ui-search source=regions searchFields=country onSearchQuery=(action (mut query)) onSelect=(action "selectRegion")}}
-			  <input class="prompt" type="text" placeholder="Regions in {{selectedCountry.title}}">
-			  <div class="results"></div>
-			{{/ui-search}}
-		{{/if}}
-	</div> -->
+		{{#power-select
+      search=(action "searchCountries")
+      selected=country
+      placeholder="search for country"
+      onchange=(action (mut country))
+      as | countries |
+    }}
+      {{countries.attributes.name}}
+    {{/power-select}}
+    
+    {{#if country}}
+    	{{#power-select
+	      search=(action "searchRegions")
+	      selected=region
+	      placeholder=regionPlaceholder
+	      onchange=(action (mut region))
+	      as | regions |
+	    }}
+	      {{regions.attributes.name}}
+	    {{/power-select}}
+    {{/if}}
+
 	{{nav-buttons sendChangeRoute="changeRoute" next="data"}}
 </div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,0 +1,26 @@
+export default function() {
+
+  // These comments are here to help you get started. Feel free to delete them.
+
+  /*
+    Config (with defaults).
+
+    Note: these only affect routes defined *after* them!
+  */
+
+  // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
+  // this.namespace = '';    // make this `/api`, for example, if your API is namespaced
+  // this.timing = 400;      // delay for each request, automatically set to 0 during testing
+
+  /*
+    Shorthand cheatsheet:
+
+    this.get('/posts');
+    this.post('/posts');
+    this.get('/posts/:id');
+    this.put('/posts/:id'); // or this.patch
+    this.del('/posts/:id');
+
+    http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
+  */
+}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -23,4 +23,6 @@ export default function() {
 
     http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
   */
+
+  this.get('/countries');
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -9,7 +9,7 @@ export default function() {
   */
 
   // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
-  // this.namespace = '';    // make this `/api`, for example, if your API is namespaced
+  this.namespace = '/api';    // make this `/api`, for example, if your API is namespaced
   // this.timing = 400;      // delay for each request, automatically set to 0 during testing
 
   /*
@@ -24,5 +24,12 @@ export default function() {
     http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
   */
 
-  this.get('/countries');
+  this.get('/countries', () => {
+    return {
+      countries: [
+        {id: 1, name: "United States"},
+        {id: 2, name: "Canada"}
+      ]
+    };
+  });
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -24,12 +24,13 @@ export default function() {
     http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
   */
 
-  this.get('/countries', () => {
-    return {
-      countries: [
-        {id: 1, name: "United States"},
-        {id: 2, name: "Canada"}
-      ]
-    };
+  this.get('/countries', (schema, request) => {
+    // return {
+    //   countries: [
+    //     {id: 1, name: "United States"},
+    //     {id: 2, name: "Canada"}
+    //   ]
+    // };
+    return schema.countries.all();
   });
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -24,11 +24,13 @@ export default function() {
     http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
   */
 
-  this.get('/countries', (schema, request) => {
-    console.log(request)
+  this.get('/countries', (schema) => {
+    // returns all data from mirage/fixtures/countries.js
     return schema.countries.all();
   });
-  this.get('/regions', (schema, request) => {
-    return schema.regions.all();
+  this.get('/regions/:countryShortCode', (schema, request) => {
+    var countryCode = request.params.countryShortCode;
+    // returns data from mirage/fixtures/regions.js for country matching the country code provided in the request
+    return schema.db.regions.findBy({countryShortCode: countryCode}).regions;
   });
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -25,12 +25,9 @@ export default function() {
   */
 
   this.get('/countries', (schema, request) => {
-    // return {
-    //   countries: [
-    //     {id: 1, name: "United States"},
-    //     {id: 2, name: "Canada"}
-    //   ]
-    // };
     return schema.countries.all();
+  });
+  this.get('/regions', (schema, request) => {
+    return schema.regions.all();
   });
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -25,6 +25,7 @@ export default function() {
   */
 
   this.get('/countries', (schema, request) => {
+    console.log(request)
     return schema.countries.all();
   });
   this.get('/regions', (schema, request) => {

--- a/mirage/fixtures/countries.js
+++ b/mirage/fixtures/countries.js
@@ -1,0 +1,7 @@
+export default [
+  {id: 1, name: 'United States'},
+  {id: 2, name: 'Canada'},
+  {id: 3, name: 'Mexico'},
+  {id: 4, name: 'Brazil'},
+  {id: 5, name: 'Chile'},
+];

--- a/mirage/fixtures/countries.js
+++ b/mirage/fixtures/countries.js
@@ -1,7 +1,17 @@
 export default [
-  {id: 1, name: 'United States'},
-  {id: 2, name: 'Canada'},
-  {id: 3, name: 'Mexico'},
-  {id: 4, name: 'Brazil'},
-  {id: 5, name: 'Chile'},
+  {
+  	id: 1,
+  	name: 'United States',
+  	countryShortCode: 'US'
+  },
+  {
+  	id: 2,
+  	name: 'Canada',
+  	countryShortCode: 'CA'
+  },
+  {
+  	id: 3,
+  	name: 'Mexico',
+  	countryShortCode: 'MX'
+  }
 ];

--- a/mirage/fixtures/countries.js
+++ b/mirage/fixtures/countries.js
@@ -1,17 +1,17 @@
 export default [
-  {
-  	id: 1,
-  	name: 'United States',
-  	countryShortCode: 'US'
-  },
-  {
-  	id: 2,
-  	name: 'Canada',
-  	countryShortCode: 'CA'
-  },
-  {
-  	id: 3,
-  	name: 'Mexico',
-  	countryShortCode: 'MX'
-  }
+	{
+		id: 1,
+		name: 'United States',
+		code: 'US'
+	},
+	{
+		id: 2,
+		name: 'Canada',
+		code: 'CA'
+	},
+	{
+		id: 3,
+		name: 'Mexico',
+		code: 'MX'
+	}
 ];

--- a/mirage/fixtures/regions.js
+++ b/mirage/fixtures/regions.js
@@ -1,0 +1,7 @@
+export default [
+  {id: 1, name: 'United States'},
+  {id: 2, name: 'Canada'},
+  {id: 3, name: 'Mexico'},
+  {id: 4, name: 'Brazil'},
+  {id: 5, name: 'Chile'},
+];

--- a/mirage/fixtures/regions.js
+++ b/mirage/fixtures/regions.js
@@ -1,7 +1,448 @@
 export default [
-  {id: 1, name: 'United States'},
-  {id: 2, name: 'Canada'},
-  {id: 3, name: 'Mexico'},
-  {id: 4, name: 'Brazil'},
-  {id: 5, name: 'Chile'},
-];
+  {
+    "countryName":"Canada",
+    "countryShortCode":"CA",
+    "regions":[
+      {
+        "name":"Alberta",
+        "shortCode":"AB"
+      },
+      {
+        "name":"British Columbia",
+        "shortCode":"BC"
+      },
+      {
+        "name":"Manitoba",
+        "shortCode":"MB"
+      },
+      {
+        "name":"New Brunswick",
+        "shortCode":"NB"
+      },
+      {
+        "name":"Newfoundland and Labrador",
+        "shortCode":"NL"
+      },
+      {
+        "name":"Northwest Territories",
+        "shortCode":"NT"
+      },
+      {
+        "name":"Nova Scotia",
+        "shortCode":"NS"
+      },
+      {
+        "name":"Nunavut",
+        "shortCode":"NU"
+      },
+      {
+        "name":"Ontario",
+        "shortCode":"ON"
+      },
+      {
+        "name":"Prince Edward Island",
+        "shortCode":"PE"
+      },
+      {
+        "name":"Quebec",
+        "shortCode":"QC"
+      },
+      {
+        "name":"Saskatchewan",
+        "shortCode":"SK"
+      },
+      {
+        "name":"Yukon",
+        "shortCode":"YT"
+      }
+    ]
+  },
+  {
+    "countryName":"Mexico",
+    "countryShortCode":"MX",
+    "regions":[
+      {
+        "name":"Aguascalientes",
+        "shortCode":"AGU"
+      },
+      {
+        "name":"Baja California",
+        "shortCode":"BCN"
+      },
+      {
+        "name":"Baja California Sur",
+        "shortCode":"BCS"
+      },
+      {
+        "name":"Campeche",
+        "shortCode":"CAM"
+      },
+      {
+        "name":"Ciudad de México",
+        "shortCode":"DIF"
+      },
+      {
+        "name":"Chiapas",
+        "shortCode":"CHP"
+      },
+      {
+        "name":"Chihuahua",
+        "shortCode":"CHH"
+      },
+      {
+        "name":"Coahuila de Zaragoza",
+        "shortCode":"COA"
+      },
+      {
+        "name":"Colima",
+        "shortCode":"COL"
+      },
+      {
+        "name":"Durango",
+        "shortCode":"DUR"
+      },
+      {
+        "name":"Estado de México",
+        "shortCode":"MEX"
+      },
+      {
+        "name":"Guanajuato",
+        "shortCode":"GUA"
+      },
+      {
+        "name":"Guerrero",
+        "shortCode":"GRO"
+      },
+      {
+        "name":"Hidalgo",
+        "shortCode":"HID"
+      },
+      {
+        "name":"Jalisco",
+        "shortCode":"JAL"
+      },
+      {
+        "name":"Michoacán de Ocampo",
+        "shortCode":"MIC"
+      },
+      {
+        "name":"Morelos",
+        "shortCode":"MOR"
+      },
+      {
+        "name":"Nayarit",
+        "shortCode":"NAY"
+      },
+      {
+        "name":"Nuevo León",
+        "shortCode":"NLE"
+      },
+      {
+        "name":"Oaxaca",
+        "shortCode":"OAX"
+      },
+      {
+        "name":"Puebla",
+        "shortCode":"PUE"
+      },
+      {
+        "name":"Querétaro de Arteaga",
+        "shortCode":"QUE"
+      },
+      {
+        "name":"Quintana Roo",
+        "shortCode":"ROO"
+      },
+      {
+        "name":"San Luis Potosí",
+        "shortCode":"SLP"
+      },
+      {
+        "name":"Sinaloa",
+        "shortCode":"SIN"
+      },
+      {
+        "name":"Sonora",
+        "shortCode":"SON"
+      },
+      {
+        "name":"Tabasco",
+        "shortCode":"TAB"
+      },
+      {
+        "name":"Tamaulipas",
+        "shortCode":"TAM"
+      },
+      {
+        "name":"Tlaxcala",
+        "shortCode":"TLA"
+      },
+      {
+        "name":"Veracruz",
+        "shortCode":"VER"
+      },
+      {
+        "name":"Yucatán",
+        "shortCode":"YUC"
+      },
+      {
+        "name":"Zacatecas",
+        "shortCode":"ZAC"
+      }
+    ]
+  },
+  {
+    "countryName":"United States",
+    "countryShortCode":"US",
+    "regions":[
+      {
+        "name":"Alabama",
+        "shortCode":"AL"
+      },
+      {
+        "name":"Alaska",
+        "shortCode":"AK"
+      },
+      {
+        "name":"American Samoa",
+        "shortCode":"AS"
+      },
+      {
+        "name":"Arizona",
+        "shortCode":"AZ"
+      },
+      {
+        "name":"Arkansas",
+        "shortCode":"AR"
+      },
+      {
+        "name":"California",
+        "shortCode":"CA"
+      },
+      {
+        "name":"Colorado",
+        "shortCode":"CO"
+      },
+      {
+        "name":"Connecticut",
+        "shortCode":"CT"
+      },
+      {
+        "name":"Delaware",
+        "shortCode":"DE"
+      },
+      {
+        "name":"District of Columbia",
+        "shortCode":"DC"
+      },
+      {
+        "name":"Micronesia",
+        "shortCode":"FM"
+      },
+      {
+        "name":"Florida",
+        "shortCode":"FL"
+      },
+      {
+        "name":"Georgia",
+        "shortCode":"GA"
+      },
+      {
+        "name":"Guam",
+        "shortCode":"GU"
+      },
+      {
+        "name":"Hawaii",
+        "shortCode":"HI"
+      },
+      {
+        "name":"Idaho",
+        "shortCode":"ID"
+      },
+      {
+        "name":"Illinois",
+        "shortCode":"IL"
+      },
+      {
+        "name":"Indiana",
+        "shortCode":"IN"
+      },
+      {
+        "name":"Iowa",
+        "shortCode":"IA"
+      },
+      {
+        "name":"Kansas",
+        "shortCode":"KS"
+      },
+      {
+        "name":"Kentucky",
+        "shortCode":"KY"
+      },
+      {
+        "name":"Louisiana",
+        "shortCode":"LA"
+      },
+      {
+        "name":"Maine",
+        "shortCode":"ME"
+      },
+      {
+        "name":"Marshall Islands",
+        "shortCode":"MH"
+      },
+      {
+        "name":"Maryland",
+        "shortCode":"MD"
+      },
+      {
+        "name":"Massachusetts",
+        "shortCode":"MA"
+      },
+      {
+        "name":"Michigan",
+        "shortCode":"MI"
+      },
+      {
+        "name":"Minnesota",
+        "shortCode":"MN"
+      },
+      {
+        "name":"Mississippi",
+        "shortCode":"MS"
+      },
+      {
+        "name":"Missouri",
+        "shortCode":"MO"
+      },
+      {
+        "name":"Montana",
+        "shortCode":"MT"
+      },
+      {
+        "name":"Nebraska",
+        "shortCode":"NE"
+      },
+      {
+        "name":"Nevada",
+        "shortCode":"NV"
+      },
+      {
+        "name":"New Hampshire",
+        "shortCode":"NH"
+      },
+      {
+        "name":"New Jersey",
+        "shortCode":"NJ"
+      },
+      {
+        "name":"New Mexico",
+        "shortCode":"NM"
+      },
+      {
+        "name":"New York",
+        "shortCode":"NY"
+      },
+      {
+        "name":"North Carolina",
+        "shortCode":"NC"
+      },
+      {
+        "name":"North Dakota",
+        "shortCode":"ND"
+      },
+      {
+        "name":"Northern Mariana Islands",
+        "shortCode":"MP"
+      },
+      {
+        "name":"Ohio",
+        "shortCode":"OH"
+      },
+      {
+        "name":"Oklahoma",
+        "shortCode":"OK"
+      },
+      {
+        "name":"Oregon",
+        "shortCode":"OR"
+      },
+      {
+        "name":"Palau",
+        "shortCode":"PW"
+      },
+      {
+        "name":"Pennsylvania",
+        "shortCode":"PA"
+      },
+      {
+        "name":"Puerto Rico",
+        "shortCode":"PR"
+      },
+      {
+        "name":"Rhode Island",
+        "shortCode":"RI"
+      },
+      {
+        "name":"South Carolina",
+        "shortCode":"SC"
+      },
+      {
+        "name":"South Dakota",
+        "shortCode":"SD"
+      },
+      {
+        "name":"Tennessee",
+        "shortCode":"TN"
+      },
+      {
+        "name":"Texas",
+        "shortCode":"TX"
+      },
+      {
+        "name":"Utah",
+        "shortCode":"UT"
+      },
+      {
+        "name":"Vermont",
+        "shortCode":"VT"
+      },
+      {
+        "name":"Virgin Islands",
+        "shortCode":"VI"
+      },
+      {
+        "name":"Virginia",
+        "shortCode":"VA"
+      },
+      {
+        "name":"Washington",
+        "shortCode":"WA"
+      },
+      {
+        "name":"West Virginia",
+        "shortCode":"WV"
+      },
+      {
+        "name":"Wisconsin",
+        "shortCode":"WI"
+      },
+      {
+        "name":"Wyoming",
+        "shortCode":"WY"
+      },
+      {
+        "name":"Armed Forces Americas",
+        "shortCode":"AA"
+      },
+      {
+        "name":"Armed Forces Europe, Canada, Africa and Middle East",
+        "shortCode":"AE"
+      },
+      {
+        "name":"Armed Forces Pacific",
+        "shortCode":"AP"
+      }
+    ]
+  }
+]

--- a/mirage/models/country.js
+++ b/mirage/models/country.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/mirage/models/region.js
+++ b/mirage/models/region.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,0 +1,9 @@
+export default function(/* server */) {
+
+  /*
+    Seed your development database using your factories.
+    This data will not be loaded in your tests.
+  */
+
+  // server.createList('post', 10);
+}

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,4 +1,4 @@
-export default function(/* server */) {
+export default function( server ) {
 
   /*
     Seed your development database using your factories.
@@ -6,4 +6,5 @@ export default function(/* server */) {
   */
 
   // server.createList('post', 10);
+  server.loadFixtures('countries');
 }

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -7,4 +7,5 @@ export default function( server ) {
 
   // server.createList('post', 10);
   server.loadFixtures('countries');
+  server.loadFixtures('regions');
 }

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -1,0 +1,4 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({
+});

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-data": "~2.14.9",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-power-select": "^1.9.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.1",
     "ember-truth-helpers": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-mirage": "^0.3.4",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -2,4 +2,7 @@ import Ember from 'ember';
 
 export default function destroyApp(application) {
   Ember.run(application, 'destroy');
+  if (window.server) {
+    window.server.shutdown();
+  }
 }


### PR DESCRIPTION
This adds ember-cli-mirage for use as a test API for development. Fixture data for countries (a small dataset) and regions (data for all regions in the three available countries) is used to populate dropdowns. The selected country and region are added to the submission record.