### PR TITLE
use house number instead of number, just in templating

### DIFF
--- a/app/templates/data-format.hbs
+++ b/app/templates/data-format.hbs
@@ -6,7 +6,15 @@
         {{#each-in model.submission.oaFields as |field properties|}}
           {{#unless (eq field "lon")}}
             {{#unless (eq field "lat")}}
-              <th><a onClick={{action "goToField" field}} class={{if (not-eq currentField field) "inactiveField"}}>{{field}}</a></th>
+              <th>
+                <a onClick={{action "goToField" field}} class={{if (not-eq currentField field) "inactiveField"}}>
+                  {{#if (eq field "number")}}
+                    house number
+                  {{else}}
+                    {{field}}
+                  {{/if}}
+                </a>
+              </th>
             {{/unless}}
           {{/unless}}
           {{#if (eq field "lon")}}

--- a/app/templates/review.hbs
+++ b/app/templates/review.hbs
@@ -120,7 +120,13 @@
           <tbody>
             <tr>
               <td class="two wide column">Field</td>
-              <td>{{field}}</td>
+              <td>
+                {{#if (eq field "number")}}
+                  house number
+                {{else}}
+                  {{field}}
+                {{/if}}
+              </td>
             </tr>
             <tr>
               <td>Column(s)</td>


### PR DESCRIPTION
Uses the term "house number" in column heading of data-format step and in submission review step, rather than just "number". The phrasing is only changed in templating, and it can be changed to "building number" if this is better.

Closes #118 