### PR TITLE
minor fix

### DIFF
--- a/app/templates/data-format.hbs
+++ b/app/templates/data-format.hbs
@@ -59,7 +59,13 @@
     {{#if (eq field currentField)}}
       <form class="ui form segment">
         <div class="field">
-          <label>{{field}}</label>
+          <label>
+            {{#if (eq field "number")}}
+              house number 
+            {{else}}
+              {{field}}
+            {{/if}}
+          </label>
           <div class="ui stackable three column center aligned grid">
             <div class="sixteen wide column">
               {{#unless (eq properties.function "join")}}


### PR DESCRIPTION
Noticed that on the data-format page, under the table it was still displaying "number" instead of "house number". Fixed it so that it's displaying "house number" instead when that is the current field. 