### PR TITLE
remove mapzen search info

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -7,8 +7,6 @@ module.exports = function(environment) {
     environment,
     rootURL: '/',
     locationType: 'hash',
-    // temporary key created for this project. The usage should not surpass the free level, but TriMet should create a new key under their own accout.
-    searchKey: 'mapzen-CqrszPU',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -24,7 +24,7 @@ export default function() {
     http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
   */
   // passthough whitelists this domain to avoid Mirage error
-  // this.passthrough('https://search.mapzen.com/v1/**');
+  // this.passthrough('');
  
   this.get('/responses', () => {
     return {


### PR DESCRIPTION
This removes the mapzen search key, as it's no longer needed.

Closes #138 